### PR TITLE
Implement basic robo advisor flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# -
+# Mock Robo Advisor
+
+This is a minimal Flask web application demonstrating two flows:
+
+1. **Scenario Investment** – enter a scenario and execute a mock trade.
+2. **Feature Search** – search for companies by describing features in natural language.
+
+Both flows use placeholders instead of real trading or data APIs so it can be run without additional setup.
+
+Run the application with:
+
+```
+python app.py
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,70 @@
+from flask import Flask, render_template, request, redirect, url_for
+from datetime import datetime
+import json
+
+app = Flask(__name__)
+
+# In-memory storage for demo purposes
+scenarios = []
+features = []
+
+# Placeholder trade execution function
+def execute_trade(action, symbol, amount):
+    print(f"[MOCK TRADE] {action} {amount} of {symbol}")
+
+# Placeholder news checker
+def check_news_for_scenario(scenario):
+    print(f"[MOCK NEWS CHECK] Searching news for: {scenario['keywords']}")
+    # In a real implementation this would fetch news from an API
+    return []
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/scenario', methods=['GET', 'POST'])
+def scenario():
+    if request.method == 'POST':
+        symbol = request.form['symbol']
+        scenario_text = request.form['scenario']
+        amount = request.form['amount']
+        keywords = request.form['keywords']
+        scenario = {
+            'symbol': symbol,
+            'scenario': scenario_text,
+            'amount': amount,
+            'keywords': keywords,
+            'created': datetime.now()
+        }
+        scenarios.append(scenario)
+        execute_trade('BUY', symbol, amount)
+        return redirect(url_for('scenario_result', idx=len(scenarios)-1))
+    return render_template('scenario.html')
+
+@app.route('/scenario/<int:idx>')
+def scenario_result(idx):
+    scenario = scenarios[idx]
+    news = check_news_for_scenario(scenario)
+    return render_template('scenario_result.html', scenario=scenario, news=news)
+
+@app.route('/feature', methods=['GET', 'POST'])
+def feature():
+    if request.method == 'POST':
+        query = request.form['query']
+        # Placeholder for GPT understanding
+        structured = {'query': query}
+        features.append(structured)
+        return redirect(url_for('feature_confirm', idx=len(features)-1))
+    return render_template('feature.html')
+
+@app.route('/feature/confirm/<int:idx>', methods=['GET', 'POST'])
+def feature_confirm(idx):
+    structured = features[idx]
+    if request.method == 'POST':
+        # Placeholder: assume user confirms and we fetch companies from DART
+        companies = ['COMPANY_A', 'COMPANY_B', 'COMPANY_C']
+        return render_template('feature_result.html', structured=structured, companies=companies)
+    return render_template('feature_confirm.html', structured=structured)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/templates/feature.html
+++ b/templates/feature.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Feature Search</title>
+</head>
+<body>
+  <h1>Feature Search</h1>
+  <form method="post">
+    <label>Query: <input name="query" required></label><br>
+    <button type="submit">Submit</button>
+  </form>
+  <p><a href="{{ url_for('index') }}">Back</a></p>
+</body>
+</html>

--- a/templates/feature_confirm.html
+++ b/templates/feature_confirm.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Confirm Query</title>
+</head>
+<body>
+  <h1>Confirm Query</h1>
+  <p>GPT understood your query as: {{ structured['query'] }}</p>
+  <form method="post">
+    <button type="submit">Looks good</button>
+  </form>
+  <p><a href="{{ url_for('index') }}">Cancel</a></p>
+</body>
+</html>

--- a/templates/feature_result.html
+++ b/templates/feature_result.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Feature Results</title>
+</head>
+<body>
+  <h1>Search Results</h1>
+  <p>Query: {{ structured['query'] }}</p>
+  <ul>
+    {% for c in companies %}
+    <li>{{ c }} <button>Buy</button></li>
+    {% endfor %}
+  </ul>
+  <p><a href="{{ url_for('index') }}">Home</a></p>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Mock Robo Advisor</title>
+</head>
+<body>
+  <h1>Mock Robo Advisor</h1>
+  <ul>
+    <li><a href="{{ url_for('scenario') }}">Scenario Investment</a></li>
+    <li><a href="{{ url_for('feature') }}">Feature Search</a></li>
+  </ul>
+</body>
+</html>

--- a/templates/scenario.html
+++ b/templates/scenario.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Scenario Investment</title>
+</head>
+<body>
+  <h1>Scenario Investment</h1>
+  <form method="post">
+    <label>Symbol: <input name="symbol" required></label><br>
+    <label>Scenario: <input name="scenario" required></label><br>
+    <label>Keywords for news: <input name="keywords" required></label><br>
+    <label>Amount: <input name="amount" required></label><br>
+    <button type="submit">Execute</button>
+  </form>
+  <p><a href="{{ url_for('index') }}">Back</a></p>
+</body>
+</html>

--- a/templates/scenario_result.html
+++ b/templates/scenario_result.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Scenario Executed</title>
+</head>
+<body>
+  <h1>Scenario Executed</h1>
+  <p>Symbol: {{ scenario['symbol'] }}</p>
+  <p>Scenario: {{ scenario['scenario'] }}</p>
+  <p>Amount: {{ scenario['amount'] }}</p>
+  <h2>News</h2>
+  {% if news %}
+    <ul>
+    {% for n in news %}
+      <li>{{ n }}</li>
+    {% endfor %}
+    </ul>
+  {% else %}
+    <p>No news yet.</p>
+  {% endif %}
+  <p><a href="{{ url_for('index') }}">Home</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a minimal Flask application
- support scenario-based investing and feature search flows
- use simple HTML templates for each page
- document running the app in README

## Testing
- `python3 --version`
- `python app.py & sleep 5; pkill -f app.py`

------
https://chatgpt.com/codex/tasks/task_e_684d79690d548321811e8f69f2c27f29